### PR TITLE
Fix haddock build

### DIFF
--- a/Data/GetField.hs
+++ b/Data/GetField.hs
@@ -10,7 +10,6 @@
 #endif
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
--- ^ Enables the default implementation of Extractor as of GHC 8.0
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 


### PR DESCRIPTION
`stack build --haddock` was failing with
```
Data/GetField.hs:1:1: error:
    File name does not match module name:
    Saw: ‘Main’
    Expected: ‘Data.GetField’
```

This is likely a problem with cabal using a ghetto cpphs, cf.
https://ghc.haskell.org/trac/ghc/ticket/8143
https://github.com/haskell/cabal/issues/883