### PR TITLE
Fail with Prelude.fail in FromJSON instances

### DIFF
--- a/src/Database/PostgreSQL/ORM/Model.hs
+++ b/src/Database/PostgreSQL/ORM/Model.hs
@@ -166,7 +166,7 @@ instance A.ToJSON DBKey where
 instance A.FromJSON DBKey where
   parseJSON (A.Number a) = return $ DBKey (floor a)
   parseJSON A.Null = return NullKey
-  parseJSON _ = error "Expected Number or Null"
+  parseJSON _ = fail "Expected Number or Null"
 
 instance Eq DBKey where
   (DBKey a) == (DBKey b) = a == b
@@ -206,7 +206,7 @@ instance A.ToJSON (GDBRef t a) where
 
 instance A.FromJSON (GDBRef t a) where
   parseJSON (A.Number n) = return $ DBRef (floor n)
-  parseJSON _ = error "Expected Number"
+  parseJSON _ = fail "Expected Number"
 
 instance (Model t) => Show (GDBRef rt t) where
   showsPrec n (DBRef k) = showsPrec n k


### PR DESCRIPTION
Failing with error causes an exception to be thrown while decoding the value, as opposed to a nice error message with a JSON path when the parser fails with Prelude.fail.

Before:
```
$ eitherDecode "true" :: Either String DBKey
*** Exception: Expected Number or Null
CallStack (from HasCallStack):
  error, called at .../postgresql-orm/src/Database/PostgreSQL/ORM/Model.hs:169:17 in main:Database.PostgreSQL.ORM.Model
```

With this PR:
```
$ eitherDecode "true" :: Either String DBKey
Left "Error in $: Expected Number or Null"
```

Note that the issue isn't just the error message, the exception is usually very unexpected coming out of JSON decoding.